### PR TITLE
Fix DNS flag

### DIFF
--- a/dns-config/README.md
+++ b/dns-config/README.md
@@ -9,7 +9,7 @@ sudo yum -y install bind bind-utils
 **Configure firewall rules**
 
 ```
-sudo firewall-cmd --add-services=dns --permanent
+sudo firewall-cmd --add-service=dns --permanent
 sudo firewall-cmd --reload
 ```
 


### PR DESCRIPTION
With *services*:
```
# sudo firewall-cmd --add-services=dns --permanent
usage: see firewall-cmd man page
firewall-cmd: error: unrecognized arguments: --add-services=dns
```

With *service* it works